### PR TITLE
fix: undefined method run_n_unit_test_suite

### DIFF
--- a/lib/snowglobe/command_runner.rb
+++ b/lib/snowglobe/command_runner.rb
@@ -39,6 +39,10 @@ module Snowglobe
       yield self if block_given?
     end
 
+    def add_env(env)
+      @env = env.merge(@env)
+    end
+
     def formatted_command
       [formatted_env, Shellwords.join(command)]
         .reject(&:empty?)

--- a/lib/snowglobe/project.rb
+++ b/lib/snowglobe/project.rb
@@ -21,7 +21,8 @@ module Snowglobe
       :run!,
       :run_rspec_tests,
       :run_rspec_test_suite,
-      :run_n_unit_tests
+      :run_n_unit_tests,
+      :run_n_unit_test_suite
     )
 
     def initialize

--- a/lib/snowglobe/project_command_runner.rb
+++ b/lib/snowglobe/project_command_runner.rb
@@ -12,7 +12,7 @@ module Snowglobe
 
     def run_n_unit_test_suite
       run_rake_tasks("test") do |runner|
-        runner.env["TESTOPTS"] = "-v"
+        runner.add_env("TESTOPTS" => "-v")
       end
     end
 


### PR DESCRIPTION
Running shoulda-context tests is currently not possible due to some issues. In version 0.3.0, the absence of JavaScript skipping causes problems during Rails 6.0 installation. Although the master branch already initializes Rails projects with "--skip-javascript", another error crops up: "undefined method 'run_n_unit_test_suite'". This occurs because this method has been removed from the 'def_delegators' method. Once I addressed this, a new error emerged, stating that ".env" is a private attribute. Instead of making it public, I decided to introduce the "add_env" method to configure the missing environment variable.

I intend to make a version for snowglobe after finishing adding all ruby and rails missing.